### PR TITLE
Calling bottle :unneeded is deprecated

### DIFF
--- a/speedtest.rb
+++ b/speedtest.rb
@@ -4,8 +4,6 @@ class Speedtest < Formula
   url "https://install.speedtest.net/app/cli/ookla-speedtest-1.0.0-macosx.tgz"
   sha256 "8d0af8a81e668fbf04b7676f173016976131877e9fbdcd0a396d4e6b70a5e8f4"
 
-  bottle :unneeded
-
   def install
     bin.install "./speedtest"
     man.mkpath


### PR DESCRIPTION
The latest brew produces the following deprecation warning:

```
Warning: Calling bottle :unneeded is deprecated! There is no replacement.
Please report this issue to the teamookla/speedtest tap (not Homebrew/brew or Homebrew/core):
  /usr/local/Homebrew/Library/Taps/teamookla/homebrew-speedtest/speedtest.rb:7
```
